### PR TITLE
add 'notbuilt' to list of job colors

### DIFF
--- a/autojenkins/run.py
+++ b/autojenkins/run.py
@@ -11,6 +11,7 @@ COLOR_MEANING = {
     'aborted': ('1;37', 'ABORTED'),
     'disabled': ('0;37', 'DISABLED'),
     'grey': ('1;37', 'NOT BUILT'),
+    'notbuilt': ('1;37', 'NOT BUILT'),
 }
 
 


### PR DESCRIPTION
Getting this error when listing an upbuilt job:

Traceback (most recent call last):
File "C:\Teamcity\BuildAgent2\work\3676ab95343f4f4e\env\Scripts\ajk-list-script.py", line 9, in <module>
load_entry_point('autojenkins==0.9.0', 'console_scripts', 'ajk-list')()
File "C:\Teamcity\BuildAgent2\work\3676ab95343f4f4e\env\lib\site-packages\autojenkins\run.py", line 200, in list
list_jobs(host, options, not options.color, options.raw)
File "C:\Teamcity\BuildAgent2\work\3676ab95343f4f4e\env\lib\site-packages\autojenkins\run.py", line 130, in list_jobs
out = COLOR_MEANING[color][position]
KeyError: 'notbuilt'
[14:09:03][Step 1/1] Process exited with code 1
