### PR TITLE
Fix incorrect error message in copy_job.

### DIFF
--- a/autojenkins/jobs.py
+++ b/autojenkins/jobs.py
@@ -254,7 +254,7 @@ class Jenkins(object):
         Create a job from a template job.
         """
         if not self.job_exists(template_job):
-            raise JobInexistent("Template job '%s' doesn't exists" % jobname)
+            raise JobInexistent("Template job '%s' doesn't exists" % template_job)
 
         if self.job_exists(jobname):
             raise JobExists("Another job with the name '%s'already exists"


### PR DESCRIPTION
In copy_job when the template does not exist, the error message
incorrectly uses the name of the job to be created instead of the name
of the template job.
