### PR TITLE
Add support to update jobs, if they exist.

### DIFF
--- a/autojenkins/jobs.py
+++ b/autojenkins/jobs.py
@@ -249,14 +249,14 @@ class Jenkins(object):
                                     headers={'Content-Type': 'application/xml'}
                                     )
 
-    def create_copy(self, jobname, template_job, enable=True, update=False, **context):
+    def create_copy(self, jobname, template_job, enable=True, _force=False, **context):
         """
         Create a job from a template job.
         """
         if not self.job_exists(template_job):
             raise JobInexistent("Template job '%s' doesn't exists" % template_job)
 
-        if not update and self.job_exists(jobname):
+        if not _force and self.job_exists(jobname):
             raise JobExists("Another job with the name '%s'already exists"
                             % jobname)
 
@@ -273,7 +273,7 @@ class Jenkins(object):
             config = config.replace('<disabled>true</disabled>',
                                     '<disabled>false</disabled>')
 
-        if update:
+        if _force:
             return self.set_config_xml(jobname, config)
         else:
             return self._build_post(NEWJOB,

--- a/autojenkins/tests/test_unit_jobs.py
+++ b/autojenkins/tests/test_unit_jobs.py
@@ -182,6 +182,21 @@ class TestJenkins(TestCase):
             proxies={},
             verify=True)
 
+    @patch('autojenkins.jobs.Jenkins.job_exists')
+    def test_create_copy_forced(self, job_exists, requests):
+        job_exists.side_effect = side_effect_job_exists
+        requests.get.return_value = mock_response('create_copy.txt')
+        requests.post.return_value = mock_response()
+        self.jenkins.create_copy('name', 'template', _force=True, value='2')
+        CFG = "<value>2</value><disabled>false</disabled>"
+        requests.post.assert_called_once_with(
+            'http://jenkins/job/name/config.xml',
+            headers={'Content-Type': 'application/xml'},
+            data=CFG,
+            auth=None,
+            proxies={},
+            verify=True)
+
     def test_transfer(self, requests):
         requests.get.return_value = mock_response('transfer.txt')
         requests.post.return_value = mock_response()


### PR DESCRIPTION
Added an optional argument to create_copy(), to indicate whether to
update the job if it already exists.
