### PR TITLE
Create new job if job does not exists.

### DIFF
--- a/autojenkins/jobs.py
+++ b/autojenkins/jobs.py
@@ -256,7 +256,9 @@ class Jenkins(object):
         if not self.job_exists(template_job):
             raise JobInexistent("Template job '%s' doesn't exists" % template_job)
 
-        if not _force and self.job_exists(jobname):
+        target_job_exists = self.job_exists(jobname)
+
+        if not _force and target_job_exists:
             raise JobExists("Another job with the name '%s'already exists"
                             % jobname)
 
@@ -273,7 +275,7 @@ class Jenkins(object):
             config = config.replace('<disabled>true</disabled>',
                                     '<disabled>false</disabled>')
 
-        if _force:
+        if target_job_exists:
             return self.set_config_xml(jobname, config)
         else:
             return self._build_post(NEWJOB,

--- a/autojenkins/tests/test_unit_jobs.py
+++ b/autojenkins/tests/test_unit_jobs.py
@@ -183,8 +183,24 @@ class TestJenkins(TestCase):
             verify=True)
 
     @patch('autojenkins.jobs.Jenkins.job_exists')
-    def test_create_copy_forced(self, job_exists, requests):
+    def test_create_copy_forced_job_exists(self, job_exists, requests):
         job_exists.side_effect = side_effect_job_exists
+        requests.get.return_value = mock_response('create_copy.txt')
+        requests.post.return_value = mock_response()
+        self.jenkins.create_copy('job', 'template', _force=True, value='2')
+        CFG = "<value>2</value><disabled>false</disabled>"
+        requests.post.assert_called_once_with(
+            'http://jenkins/createItem',
+            auth=None,
+            headers={'Content-Type': 'application/xml'},
+            params={'name': 'job'},
+            data=CFG,
+            proxies={},
+            verify=True)
+
+    @patch('autojenkins.jobs.Jenkins.job_exists')
+    def test_create_copy_forced_new_job(self, job_exists, requests):
+        job_exists.return_value = True
         requests.get.return_value = mock_response('create_copy.txt')
         requests.post.return_value = mock_response()
         self.jenkins.create_copy('name', 'template', _force=True, value='2')

--- a/autojenkins/tests/test_unit_jobs.py
+++ b/autojenkins/tests/test_unit_jobs.py
@@ -200,7 +200,7 @@ class TestJenkins(TestCase):
 
     @patch('autojenkins.jobs.Jenkins.job_exists')
     def test_create_copy_forced_new_job(self, job_exists, requests):
-        job_exists.return_value = True
+        job_exists.side_effect = side_effect_job_exists
         requests.get.return_value = mock_response('create_copy.txt')
         requests.post.return_value = mock_response()
         self.jenkins.create_copy('name', 'template', _force=True, value='2')


### PR DESCRIPTION
In create_copy(), a new job is created, if _force is set to
False. Instead, a new job should be created if the job does not exist.