### PR TITLE
Return explicit unicode response

### DIFF
--- a/autojenkins/jobs.py
+++ b/autojenkins/jobs.py
@@ -151,7 +151,7 @@ class Jenkins(object):
         (SUCCESS, UNSTABLE or FAILED).
         """
         response = self._build_get(LIST)
-        jobs = eval(response.content).get('jobs', [])
+        jobs = eval(response.text).get('jobs', [])
         return [(job['name'], job['color']) for job in jobs]
 
     def job_exists(self, jobname):
@@ -171,7 +171,7 @@ class Jenkins(object):
         Get all information for a job as a Python object (dicts & lists).
         """
         response = self._build_get(JOBINFO, jobname)
-        return eval(response.content)
+        return eval(response.text)
 
     def build_info(self, jobname, build_number=None):
         """
@@ -184,7 +184,7 @@ class Jenkins(object):
         else:
             args = (LAST_BUILD, jobname)
         response = self._build_get(*args)
-        return eval(response.content)
+        return eval(response.text)
 
     def build_console(self, jobname, build_number=None):
         """
@@ -197,7 +197,7 @@ class Jenkins(object):
         else:
             args = (CONSOLE, jobname, "lastBuild")
         response = self._build_get(*args)
-        return response.content
+        return response.text
 
     def last_build_console(self, jobname):
         """
@@ -216,7 +216,7 @@ class Jenkins(object):
         Get full report of last build.
         """
         response = self._build_get(LAST_REPORT, jobname)
-        return eval(response.content)
+        return eval(response.text)
 
     def last_result(self, jobname):
         """
@@ -224,21 +224,21 @@ class Jenkins(object):
         """
         last_result_url = self.job_info(jobname)['lastBuild']['url']
         response = self._http_get(last_result_url + API)
-        return eval(response.content)
+        return eval(response.text)
 
     def last_success(self, jobname):
         """
         Return information about the last successful build.
         """
         response = self._build_get(LAST_SUCCESS, jobname)
-        return eval(response.content)
+        return eval(response.text)
 
     def get_config_xml(self, jobname):
         """
         Get the ``config.xml`` file that contains the job definition.
         """
         response = self._build_get(CONFIG, jobname)
-        return response.content
+        return response.text
 
     def set_config_xml(self, jobname, config):
         """

--- a/autojenkins/tests/test_unit_jobs.py
+++ b/autojenkins/tests/test_unit_jobs.py
@@ -25,11 +25,11 @@ def load_fixture(name):
 def mock_response(fixture=None, status=200):
     response = Mock()
     if fixture is None:
-        response.content = ''
+        response.text = ''
     elif isinstance(fixture, dict):
-        response.content = str(fixture)
+        response.text = str(fixture)
     else:
-        response.content = load_fixture(fixture)
+        response.text = load_fixture(fixture)
     response.status_code = status
     return response
 
@@ -67,7 +67,7 @@ class TestJenkins(TestCase):
 
     def test_last_result(self, requests, *args):
         second_response = Mock(status_code=200)
-        second_response.content = "{'result': 23}"
+        second_response.text = "{'result': 23}"
         requests.get.side_effect = [
             mock_response('job_info.txt'), second_response
         ]


### PR DESCRIPTION
Hi, the unit tests make the false assumption that the request calls always return unicode strings. Using Python 3.5, I noticed at least one response in byte string format which raised a string comparison error. I was able to resolve this by replacing all instances of response.content with response.text.