### PR TITLE
Allows listing organizational folders

### DIFF
--- a/autojenkins/jobs.py
+++ b/autojenkins/jobs.py
@@ -145,7 +145,7 @@ class Jenkins(object):
         """
         return self._http_post(self._url(url_pattern, *args), **kwargs)
 
-    def all_jobs(self):
+    def all_jobs(self, include_colorless=False):
         """
         Get a list of tuples with (name, color) of all jobs in the server.
 
@@ -154,7 +154,8 @@ class Jenkins(object):
         """
         response = self._build_get(LIST)
         jobs = eval(response.text).get('jobs', [])
-        return [(job['name'], job['color']) for job in jobs]
+        return [(job['name'], job.get('color', None)) 
+                for job in jobs if 'color' in job or include_colorless]
 
     def job_exists(self, jobname):
         jobs = self.all_jobs()

--- a/autojenkins/tests/test_unit_jobs.py
+++ b/autojenkins/tests/test_unit_jobs.py
@@ -52,7 +52,9 @@ class TestJenkins(TestCase):
         self.jenkins = Jenkins('http://jenkins')
 
     def test_all_jobs(self, requests):
-        response = {'jobs': [{'name': 'job1', 'color': 'blue'}]}
+        response = {'jobs': [
+            {'name': 'job1', 'color': 'blue'},
+            {'name': 'colorless'}]}
         requests.get.return_value = mock_response(response)
         jobs = self.jenkins.all_jobs()
         requests.get.assert_called_once_with('http://jenkins/api/python',
@@ -60,6 +62,18 @@ class TestJenkins(TestCase):
                                              proxies={},
                                              auth=None)
         self.assertEqual(jobs, [('job1', 'blue')])
+
+    def test_all_jobs_including_colorless(self, requests):
+        response = {'jobs': [
+            {'name': 'job1', 'color': 'blue'},
+            {'name': 'colorless'}]}
+        requests.get.return_value = mock_response(response)
+        jobs = self.jenkins.all_jobs(include_colorless=True)
+        requests.get.assert_called_once_with('http://jenkins/api/python',
+                                             verify=True,
+                                             proxies={},
+                                             auth=None)
+        self.assertEqual(jobs, [('job1', 'blue'), ('colorless', None)])
 
     def test_get_job_url(self, *args):
         url = self.jenkins.job_url('job123')


### PR DESCRIPTION
Organizational folders are provided by [Branch API Plugin](https://wiki.jenkins.io/display/JENKINS/Branch+API+Plugin).
They do not have status and color is not returned for them so exception is raised.
```
$ bin/python -m jenkins.get_jobs_xml
Traceback (most recent call last):
  File "~/.pyenv/versions/2.7.10/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "~/.pyenv/versions/2.7.10/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "~/workspace/develop/jenkins/get_jobs_xml.py", line 22, in <module>
    all_jobs = jenkins.all_jobs()
  File "~/workspace/develop/lib/python2.7/site-packages/autojenkins/jobs.py", line 157, in all_jobs
    return [(job['name'], job['color']) for job in jobs]
KeyError: 'color'
```
This commit changes `all_jobs` function so it skips them by default.
Additional option allows to include them.

This implementation filters by presence of the `color` parameter in a job. Alternatively we can filter by class name of the job.